### PR TITLE
Fix .node file loader, add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ This formatter exists because Mystenlabs has not yet created a formatter for Mov
 - [x] Enum definitions
 - [x] Match statements
 - [ ] Clever Assertions
+
+# Local installation for Visual Studio Code
+
+`yarn`
+
+Compile the binary: `yarn build`
+
+Build the vsce (Visual Studio Code Extensions) package: `yarn package`
+
+Debug run the extension: `F5` output is visible in `OUTPUT` (next to the terminal) when selecting `Log (Extension Host)` at the top right
+
+Install the extension: `yarn install:local`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A formatter for the SUI move language with Development features.",
     "version": "0.0.1",
     "engines": {
-        "vscode": "^1.88.0",
+        "vscode": "^1.67.2",
         "node": ">= 10"
     },
     "keywords": [
@@ -24,7 +24,7 @@
         "vscode:prepublish": "npm run esbuild-base -- --minify",
         "package": "vsce package -o dist/sui-move-formatter.vsix",
         "install:local": "code --install-extension dist/sui-move-formatter.vsix",
-        "esbuild-base": "esbuild ./src/extension.ts --bundle --loader:.node=file --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+        "esbuild-base": "esbuild ./src/extension.ts --bundle --loader:.node=copy --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
         "pretest": "yarn run compile && yarn run lint",
         "lint": "eslint src --ext ts",
         "test": "vscode-test"
@@ -32,7 +32,7 @@
     "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "18.x",
-        "@types/vscode": "^1.88.0",
+        "@types/vscode": "^1.67.0",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
         "@vscode/test-cli": "^0.0.8",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"module": "Node16",
+		"module": "esnext",
 		"target": "ES2022",
 		"outDir": "out",
 		"lib": [
@@ -8,7 +8,7 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,9 +304,9 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
-"@types/vscode@^1.88.0":
+"@types/vscode@^1.67.0":
   version "1.88.0"
-  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.88.0.tgz#2dc690237f7ef049942508c8609b6b9f5216b4d3"
   integrity sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==
 
 "@typescript-eslint/eslint-plugin@^7.4.0":


### PR DESCRIPTION
I think I got it somehow working without changing `--loader:.node=copy`, but couldn't reproduce it and with this it seems to run fine now. Tested with `rm -rf dist && yarn build && yarn package` and then running the extension.
I set the vscode engine to a lower version as I still run this.